### PR TITLE
:art: Rescue RestClient::Unauthorized exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ rvm:
   - 2.4.5
   - 2.5.3
   - ruby-head
-before_install: gem install bundler -v 1.16.5
+before_install: gem install bundler

--- a/geo_names.gemspec
+++ b/geo_names.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rest-client', '~> 2'
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'gem-release', '~> 2.0'
   spec.add_development_dependency 'pry-byebug', '~> 3.6'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/geo_names/base.rb
+++ b/lib/geo_names/base.rb
@@ -31,6 +31,8 @@ module GeoNames
 
     def make_request
       RestClient.get(url, params: params)
+    rescue RestClient::Unauthorized => e
+      e.response.to_s
     end
 
     def parse(json_string)


### PR DESCRIPTION
Before when the `username` was invalid GeoNames API returned:

- Status Code: `200 Ok`
- Body: `{ "status": { "message": "invalid user", "value": 10 } }`

Now it returns this:

- Status Code: `401 Unauthorized`
- Body: `{ "status": { "message": "invalid user", "value": 10 } }`
