### PR TITLE
fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ First you need a `Hash` with the criteria that you want to search.
 ```ruby
 # example of criteria
 criteria = {
-  country_code: 'US',
+  country: 'US',
   name: 'New York',
   featureClass: %w[P S],
   maxRows: 1,


### PR DESCRIPTION
Thank you for this gem!

I was setting up a project and noticed that the example from the README didn't seem to work if I varied the search criteria, specifically the country code.

Turns out that the API expects `country` not `country_code`, as you can see in the screen cap from [the API docs](https://www.geonames.org/export/geonames-search.html):

<img width="400" alt="api docs" src="https://github.com/user-attachments/assets/514bd449-9a8e-4562-9f5d-6b0727cdd6a3" />

I have updated the docs accordingly.
